### PR TITLE
move hex size to the end

### DIFF
--- a/imohash/imohash.py
+++ b/imohash/imohash.py
@@ -31,7 +31,7 @@ def hashfileobject(f, sample_threshhold=SAMPLE_THRESHOLD, sample_size=SAMPLE_SIZ
     hash_tmp = mmh3.hash_bytes(data)
     hash_ = hash_tmp[7::-1] + hash_tmp[16:7:-1]
     enc_size = varint.encode(size)
-    digest = enc_size + hash_[len(enc_size):]
+    digest = hash_[len(enc_size):] + enc_size
 
     return binascii.hexlify(digest).decode() if hexdigest else digest
 


### PR DESCRIPTION
make the first few letters of hex string random enough

```
#!/usr/bin/env python3
"""
Sometimes we need to use hex string to store files,
such as `e8/ac/e8ac086e6f025eb4e03430bb99ea10b0.jpg`,
or get files randomly by hex hash filename. So, the
hex hash string returned by hash function should be
random enough, especially for the first few letters.
"""
from imohash.imohash import hashfile
import os
from pprint import pprint

hash_and_files = dict()
char_count = {i: 0 for i in '0123456789abcdef'}

for home, dirs, files in os.walk('/usr/bin/'):
    for filename in files:
        path = os.path.join(home, filename)
        if not os.path.islink(path):  # ignore symbolic link
            hex_hash = hashfile(path, hexdigest=True)
            hash_and_files[hex_hash] = path
            char_count[hex_hash[:1]] += 1

hash_and_files = sorted(hash_and_files.items(), key=lambda x: x[0])

# print sorted hashes
for _hash, filename in hash_and_files:
    print(_hash, filename)

# print the number of the first char
pprint(char_count)
```

before:
```
{'0': 0,
 '1': 1,
 '2': 10,
 '3': 9,
 '4': 5,
 '5': 6,
 '6': 2,
 '7': 2,
 '8': 185,
 '9': 225,
 'a': 178,
 'b': 208,
 'c': 185,
 'd': 190,
 'e': 184,
 'f': 247}
```
after:
```
{'0': 108,
 '1': 83,
 '2': 110,
 '3': 106,
 '4': 96,
 '5': 109,
 '6': 102,
 '7': 70,
 '8': 105,
 '9': 100,
 'a': 103,
 'b': 106,
 'c': 106,
 'd': 116,
 'e': 99,
 'f': 118}
```
